### PR TITLE
Use TapActionCell's tintColor as its label textColor

### DIFF
--- a/Source/View/TapActionCell.swift
+++ b/Source/View/TapActionCell.swift
@@ -29,11 +29,6 @@ import UIKit
 /// A `UITableViewCell` subclass with the title text center aligned.
 open class TapActionCell: UITableViewCell {
 
-  private static var systemTintColor: UIColor = {
-    let _button = UIButton()
-    return _button.tintColor ?? UIColor.blue
-  }()
-
   // MARK: - Initializer
 
   /**
@@ -61,12 +56,19 @@ open class TapActionCell: UITableViewCell {
     setUpAppearance()
   }
 
+  // MARK: UIView
+
+  open override func tintColorDidChange() {
+    super.tintColorDidChange()
+    textLabel?.textColor = tintColor
+  }
+
   // MARK: Private Methods
 
   private func setUpAppearance() {
     textLabel?.numberOfLines = 0
     textLabel?.textAlignment = .center
-    textLabel?.textColor = type(of: self).systemTintColor
+    textLabel?.textColor = tintColor
   }
 
 }


### PR DESCRIPTION
This PR attempts to fix a pretty minor issue of `TapActionCell`'s `textLabel` not following the modified `tintColor` when setting a custom `tintColor` on the application's main `UIWindow` instance (which is a somewhat common approach to theming the entire app). 

Since currently the text color is derived from a temporarily created button which is never inserted into the view hierarchy, it stays equal to the default system tint color, not the (potentially) overridden one.

After this change, the label's text color will follow its `TapActionCell`'s `tintColor` which sounds like intended and reasonable behavior to me.

The downside is that overriding this text color via UIAppearance will now need to be done by manipulating `TapActionCell`'s `tintColor` property though the cell's appearance proxy, and _not_ directly through `UILabel`'s proxy (since UIAppearance will notice the property having already been modified by the cell and will not proceed with update).