### PR TITLE
Update to Swift 4.2

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ disabled_rules:
   - force_cast
   - function_body_length
   - identifier_name
+  - line_length
   - vertical_whitespace
 opt_in_rules:
   - closure_end_indentation
@@ -36,4 +37,3 @@ included:
 excluded:
   - Carthage
   - Pods
-line_length: 192

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: objective-c
 osx_image: xcode10
-matrix:
-  include:
-    - env: VERSION=latest
 cache:
   - bundler
   - cocoapods
@@ -17,7 +14,6 @@ before_script:
   - if [ -n "$DANGER_GITHUB_API_TOKEN" ]; then bundle exec danger; fi
 script:
   - set -o pipefail
-  - xcodebuild clean build -workspace QuickTableViewController.xcworkspace -scheme QuickTableViewController-iOS -sdk iphonesimulator SWIFT_VERSION=4.2 | bundle exec xcpretty -c
   - bundle exec rake "test:ios[QuickTableViewController-iOS]"
   - bundle exec rake "test:tvos[QuickTableViewController-tvOS]"
   - bash <(curl -s https://codecov.io/bash) -cF ios -J "QuickTableViewController"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - if [ -n "$DANGER_GITHUB_API_TOKEN" ]; then bundle exec danger; fi
 script:
   - set -o pipefail
-  - xcodebuild clean build -workspace QuickTableViewController.xcworkspace -scheme QuickTableViewController-iOS -sdk iphonesimulator SWIFT_VERSION=3.0 | bundle exec xcpretty -c
+  - xcodebuild clean build -workspace QuickTableViewController.xcworkspace -scheme QuickTableViewController-iOS -sdk iphonesimulator SWIFT_VERSION=4.2 | bundle exec xcpretty -c
   - bundle exec rake "test:ios[QuickTableViewController-iOS]"
   - bundle exec rake "test:tvos[QuickTableViewController-tvOS]"
   - bash <(curl -s https://codecov.io/bash) -cF ios -J "QuickTableViewController"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.3beta
+osx_image: xcode10
 matrix:
   include:
     - env: VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 before_install:
   - export LANG=en_US.UTF-8
   - xcrun instruments -s devices
-  - open -b com.apple.iphonesimulator
+  - open -a /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app
 install:
   - bundle install --without development --deployment --jobs=3 --retry=3
   - bundle exec pod install

--- a/Example-iOS/AppDelegate.swift
+++ b/Example-iOS/AppDelegate.swift
@@ -31,7 +31,9 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?
 
+  // swiftlint:disable line_length
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    // swiftlint:enable line_length
 
     if #available(iOS 9.0, *) {
       // See AppearanceViewController for the setups.

--- a/Example-iOS/AppDelegate.swift
+++ b/Example-iOS/AppDelegate.swift
@@ -31,9 +31,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?
 
-  // swiftlint:disable line_length
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-    // swiftlint:enable line_length
 
     if #available(iOS 9.0, *) {
       // See AppearanceViewController for the setups.

--- a/Example-iOS/AppDelegate.swift
+++ b/Example-iOS/AppDelegate.swift
@@ -31,7 +31,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?
 
-  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
 
     if #available(iOS 9.0, *) {
       // See AppearanceViewController for the setups.

--- a/Example-tvOS/AppDelegate.swift
+++ b/Example-tvOS/AppDelegate.swift
@@ -31,7 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?
 
-  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     window = UIWindow(frame: UIScreen.main.bounds)
     window?.rootViewController = UINavigationController(rootViewController: TableViewController())
     window?.makeKeyAndVisible()

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
     rouge (2.0.7)
-    ruby-macho (1.2.0)
+    ruby-macho (1.3.0)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)

--- a/QuickTableViewController.podspec
+++ b/QuickTableViewController.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.license       = { type: "MIT", file: "LICENSE" }
   s.author        = "bcylin"
 
-  s.swift_version           = "4.0"
+  s.swift_version           = "4.2"
   s.ios.deployment_target   = "8.0"
   s.tvos.deployment_target  = "9.0"
 

--- a/QuickTableViewController.xcodeproj/project.pbxproj
+++ b/QuickTableViewController.xcodeproj/project.pbxproj
@@ -703,18 +703,18 @@
 				TargetAttributes = {
 					B51F21A11F417037009BC2C9 = {
 						CreatedOnToolsVersion = 8.3.3;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Manual;
 					};
 					B51F21BF1F41E600009BC2C9 = {
 						CreatedOnToolsVersion = 8.3.3;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Manual;
 						TestTargetID = B51F21A11F417037009BC2C9;
 					};
 					B5334F121B8CC5BD00C64A6D = {
 						CreatedOnToolsVersion = 6.4;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1000;
 					};
 					B5334F1D1B8CC5BD00C64A6D = {
 						CreatedOnToolsVersion = 6.4;
@@ -1160,8 +1160,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -1182,8 +1181,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -1206,8 +1204,7 @@
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_TARGET_NAME = "Example-iOS";
 			};
 			name = Debug;
@@ -1230,8 +1227,7 @@
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_TARGET_NAME = "Example-iOS";
 			};
 			name = Release;
@@ -1375,8 +1371,7 @@
 				PRODUCT_NAME = QuickTableViewController;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -1397,8 +1392,7 @@
 				PRODUCT_NAME = QuickTableViewController;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/QuickTableViewController.xcodeproj/project.pbxproj
+++ b/QuickTableViewController.xcodeproj/project.pbxproj
@@ -722,6 +722,7 @@
 					};
 					B54A24252088816D00EEBA26 = {
 						CreatedOnToolsVersion = 9.3;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 					B54A242D2088816E00EEBA26 = {
@@ -730,6 +731,7 @@
 					};
 					B54A24522088D44A00EEBA26 = {
 						CreatedOnToolsVersion = 9.3;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1462,7 +1464,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1492,7 +1494,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1570,7 +1572,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1596,7 +1598,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};

--- a/Source/Model/Section.swift
+++ b/Source/Model/Section.swift
@@ -41,7 +41,7 @@ open class Section {
   // MARK: - Properties
 
   /// The text of the section title.
-  open let title: String?
+  public let title: String?
 
   /// The array of rows in the section.
   open var rows: [Row & RowStyle]

--- a/Source/Model/Subtitle.swift
+++ b/Source/Model/Subtitle.swift
@@ -39,7 +39,7 @@ public enum Subtitle: Equatable {
   case leftAligned(String)
 
   /// Returns the corresponding table view cell style.
-  public var style: UITableViewCellStyle {
+  public var style: UITableViewCell.CellStyle {
     switch self {
     case .none:          return .default
     case .belowTitle:    return .subtitle
@@ -79,7 +79,7 @@ public enum Subtitle: Equatable {
 }
 
 
-internal extension UITableViewCellStyle {
+internal extension UITableViewCell.CellStyle {
 
   var stringValue: String {
     switch self {

--- a/Source/Protocol/RowStyle.swift
+++ b/Source/Protocol/RowStyle.swift
@@ -36,13 +36,13 @@ public protocol RowStyle {
   var cellReuseIdentifier: String { get }
 
   /// The style of the table view cell to display the row.
-  var cellStyle: UITableViewCellStyle { get }
+  var cellStyle: UITableViewCell.CellStyle { get }
 
   /// The icon of the row.
   var icon: Icon? { get }
 
   /// The type of standard accessory view the cell should use.
-  var accessoryType: UITableViewCellAccessoryType { get }
+  var accessoryType: UITableViewCell.AccessoryType { get }
 
   /// The flag that indicates whether the table view cell should trigger the action when selected.
   var isSelectable: Bool { get }

--- a/Source/QuickTableViewController.swift
+++ b/Source/QuickTableViewController.swift
@@ -51,7 +51,7 @@ open class QuickTableViewController: UIViewController, UITableViewDataSource, UI
 
    - returns: An initialized `QuickTableViewController` object.
    */
-  public convenience init(style: UITableViewStyle) {
+  public convenience init(style: UITableView.Style) {
     self.init(nibName: nil, bundle: nil)
     tableView = UITableView(frame: .zero, style: style)
   }
@@ -68,7 +68,7 @@ open class QuickTableViewController: UIViewController, UITableViewDataSource, UI
     view.addSubview(tableView)
     tableView.frame = view.bounds
     tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    tableView.rowHeight = UITableViewAutomaticDimension
+    tableView.rowHeight = UITableView.automaticDimension
     tableView.estimatedRowHeight = 44
     tableView.dataSource = self
     tableView.delegate = self

--- a/Source/Rows/NavigationRow.swift
+++ b/Source/Rows/NavigationRow.swift
@@ -69,7 +69,7 @@ open class NavigationRow<T: UITableViewCell>: NavigationRowCompatible, Equatable
   }
 
   /// Returns the table view cell style for the specified subtitle.
-  public var cellStyle: UITableViewCellStyle {
+  public var cellStyle: UITableViewCell.CellStyle {
     return subtitle?.style ?? .default
   }
 
@@ -77,7 +77,7 @@ open class NavigationRow<T: UITableViewCell>: NavigationRowCompatible, Equatable
   public let icon: Icon?
 
   /// Returns `.disclosureIndicator` when action is not nil, otherwise returns `.none`.
-  public var accessoryType: UITableViewCellAccessoryType {
+  public var accessoryType: UITableViewCell.AccessoryType {
     return (action == nil) ? .none : .disclosureIndicator
   }
 

--- a/Source/Rows/OptionRow.swift
+++ b/Source/Rows/OptionRow.swift
@@ -81,13 +81,13 @@ open class OptionRow<T: UITableViewCell>: OptionRowCompatible, Equatable {
   public let cellReuseIdentifier: String = T.reuseIdentifier
 
   /// The cell style is `.default`.
-  public let cellStyle: UITableViewCellStyle = .default
+  public let cellStyle: UITableViewCell.CellStyle = .default
 
   /// The icon of the row.
   public let icon: Icon?
 
   /// Returns `.checkmark` when the row is selected, otherwise returns `.none`.
-  public var accessoryType: UITableViewCellAccessoryType {
+  public var accessoryType: UITableViewCell.AccessoryType {
     return isSelected ? .checkmark : .none
   }
 

--- a/Source/Rows/SwitchRow.swift
+++ b/Source/Rows/SwitchRow.swift
@@ -81,7 +81,7 @@ open class SwitchRow<T: SwitchCell>: SwitchRowCompatible, Equatable {
   public let cellReuseIdentifier: String = T.reuseIdentifier
 
   /// The cell style is `.default`.
-  public let cellStyle: UITableViewCellStyle = .default
+  public let cellStyle: UITableViewCell.CellStyle = .default
 
   /// The icon of the row.
   public let icon: Icon?
@@ -89,7 +89,7 @@ open class SwitchRow<T: SwitchCell>: SwitchRowCompatible, Equatable {
   #if os(iOS)
 
   /// The default accessory type is `.none`.
-  public let accessoryType: UITableViewCellAccessoryType = .none
+  public let accessoryType: UITableViewCell.AccessoryType = .none
 
   /// The `SwitchRow` should not be selectable.
   public let isSelectable: Bool = false

--- a/Source/Rows/SwitchRow.swift
+++ b/Source/Rows/SwitchRow.swift
@@ -97,7 +97,7 @@ open class SwitchRow<T: SwitchCell>: SwitchRowCompatible, Equatable {
   #elseif os(tvOS)
 
   /// Returns `.checkmark` when the `switchValue` is on, otherwise returns `.none`.
-  public var accessoryType: UITableViewCellAccessoryType {
+  public var accessoryType: UITableViewCell.AccessoryType {
     return switchValue ? .checkmark : .none
   }
 

--- a/Source/Rows/TapActionRow.swift
+++ b/Source/Rows/TapActionRow.swift
@@ -63,13 +63,13 @@ open class TapActionRow<T: TapActionCell>: TapActionRowCompatible, Equatable {
   public let cellReuseIdentifier: String = T.reuseIdentifier
 
   /// The cell style is `.default`.
-  public let cellStyle: UITableViewCellStyle = .default
+  public let cellStyle: UITableViewCell.CellStyle = .default
 
   /// The default icon is nil.
   public let icon: Icon? = nil
 
   /// The default accessory type is `.none`.
-  public let accessoryType: UITableViewCellAccessoryType = .none
+  public let accessoryType: UITableViewCell.AccessoryType = .none
 
   /// The `TapActionRow` is selectable when action is not nil.
   public var isSelectable: Bool {

--- a/Source/Views/SwitchCell.swift
+++ b/Source/Views/SwitchCell.swift
@@ -63,7 +63,7 @@ open class SwitchCell: UITableViewCell, Configurable {
 
    - returns: An initialized `SwitchCell` object.
    */
-  public override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+  public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     setUpAppearance()
   }

--- a/Source/Views/TapActionCell.swift
+++ b/Source/Views/TapActionCell.swift
@@ -42,7 +42,7 @@ open class TapActionCell: UITableViewCell {
 
    - returns: An initialized `TapActionCell` object.
    */
-  public override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+  public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: .default, reuseIdentifier: reuseIdentifier)
     setUpAppearance()
   }


### PR DESCRIPTION
- Ran the Swift 4.2 Migrator in Xcode 10
- Tests still pass
- No SwiftLint issues
- Updated `ruby-macho` to the latest version supported by CocoaPods 1.5.3

Closes https://github.com/bcylin/QuickTableViewController/issues/19.