### PR TITLE
3DTouch-TapAction: [Wip] 

### DIFF
--- a/Example-iOS/ViewControllers/AppearanceViewController.swift
+++ b/Example-iOS/ViewControllers/AppearanceViewController.swift
@@ -41,19 +41,19 @@ internal final class AppearanceViewController: QuickTableViewController {
 
     tableContents = [
       Section(title: "Switch", rows: [
-        SwitchRow(title: "SwitchCell", switchValue: true, action: { _ in })
+        SwitchRow(title: "SwitchCell", switchValue: true, actions: nil)
       ]),
 
       Section(title: "Tap Action", rows: [
-        TapActionRow(title: "TapActionCell", action: { _ in })
+        TapActionRow(title: "TapActionCell", actions: nil)
       ]),
 
       Section(title: "Navigation", rows: [
-        NavigationRow(title: "UITableViewCell", subtitle: .belowTitle(".subtitle"), action: { _ in })
+        NavigationRow(title: "UITableViewCell", subtitle: .belowTitle(".subtitle"), actions: nil)
       ]),
 
       RadioSection(title: "Radio Buttons", options: [
-        OptionRow(title: "UITableViewCell", isSelected: true, action: { _ in })
+        OptionRow(title: "UITableViewCell", isSelected: true, actions: nil)
       ])
     ]
   }

--- a/Example-iOS/ViewControllers/CustomizationViewController.swift
+++ b/Example-iOS/ViewControllers/CustomizationViewController.swift
@@ -59,13 +59,13 @@ internal final class CustomizationViewController: QuickTableViewController {
           title: "SwitchRow\n<CustomSwitchCell>",
           switchValue: true,
           customization: set(label: "0-0"),
-          action: showLog()
+          actions: [showLog()]
         ),
         CustomSwitchRow<SwitchCell>(
           title: "CustomSwitchRow\n<SwitchCell>",
           switchValue: false,
           customization: set(label: "0-1"),
-          action: showLog()
+          actions: [showLog()]
         )
       ]),
 
@@ -73,12 +73,12 @@ internal final class CustomizationViewController: QuickTableViewController {
         TapActionRow<CustomTapActionCell>(
           title: "TapActionRow\n<CustomTapActionCell>",
           customization: set(label: "1-0"),
-          action: showLog()
+          actions: [showLog()]
         ),
         CustomTapActionRow<TapActionCell>(
           title: "CustomTapActionRow\n<TapActionCell>",
           customization: set(label: "1-1"),
-          action: showLog()
+          actions: [showLog()]
         )
       ]),
 
@@ -87,25 +87,25 @@ internal final class CustomizationViewController: QuickTableViewController {
           title: "NavigationRow",
           subtitle: .none,
           customization: set(label: "2-0"),
-          action: showLog()
+          actions: [showLog()]
         ),
         NavigationRow<CustomCell>(
           title: "NavigationRow<CustomCell>",
           subtitle: .belowTitle(".subtitle"),
           customization: set(label: "2-1"),
-          action: showLog()
+          actions: [showLog()]
         ),
         CustomNavigationRow(
           title: "CustomNavigationRow",
           subtitle: .rightAligned(".value1"),
           customization: set(label: "2-2"),
-          action: showLog()
+          actions: [showLog()]
         ),
         CustomNavigationRow<CustomCell>(
           title: "CustomNavigationRow<CustomCell>",
           subtitle: .leftAligned(".value2"),
           customization: set(label: "2-3"),
-          action: showLog()
+          actions: [showLog()]
         )
       ]),
 
@@ -114,19 +114,19 @@ internal final class CustomizationViewController: QuickTableViewController {
           title: "OptionRow",
           isSelected: false,
           customization: set(label: "3-0"),
-          action: showLog()
+          actions: [showLog()]
         ),
         CustomOptionRow(
           title: "CustomOptionRow",
           isSelected: false,
           customization: set(label: "3-1"),
-          action: showLog()
+          actions: [showLog()]
         ),
         CustomOptionRow<CustomOptionCell>(
           title: "CustomOptionRow<CustomOptionCell>",
           isSelected: false,
           customization: set(label: "3-2"),
-          action: showLog()
+          actions: [showLog()]
         )
       ]),
 
@@ -155,8 +155,9 @@ internal final class CustomizationViewController: QuickTableViewController {
     }
   }
 
-  private func showLog() -> (Row) -> Void {
-    return { [weak self] in
+  private func showLog() -> RowActionType {
+    let action: (Row) -> Void = {
+      [weak self] in
       if let option = $0 as? OptionRowCompatible, !option.isSelected {
         return
       }
@@ -169,6 +170,8 @@ internal final class CustomizationViewController: QuickTableViewController {
         self?.tableView.reloadData()
       }
     }
+    let actionType: RowActionType = .defaultAction(action)
+    return actionType
   }
 
 }

--- a/Example-iOS/ViewControllers/DefaultViewController.swift
+++ b/Example-iOS/ViewControllers/DefaultViewController.swift
@@ -45,25 +45,26 @@ internal final class DefaultViewController: QuickTableViewController {
 
     tableContents = [
       Section(title: "Switch", rows: [
-        SwitchRow(title: "Setting 1", switchValue: true, icon: .image(globe), action: didToggleSwitch()),
-        SwitchRow(title: "Setting 2", switchValue: false, icon: .image(time), action: didToggleSwitch())
+        SwitchRow(title: "Setting 1", switchValue: true, icon: .image(globe), actions: [didToggleSwitch()]),
+        SwitchRow(title: "Setting 2", switchValue: false, icon: .image(time), actions: [didToggleSwitch()])
       ]),
 
       Section(title: "Tap Action", rows: [
-        TapActionRow(title: "Tap action", action: showAlert())
+        TapActionRow(title: "Tap action", actions: [showAlert()]),
+        TapActionRow(title: "Tap action1", actions: [showDetail(), show3DTouchPreview()])
       ]),
 
       Section(title: "Navigation", rows: [
         NavigationRow(title: "CellStyle.default", subtitle: .none, icon: .image(gear)),
         NavigationRow(title: "CellStyle", subtitle: .belowTitle(".subtitle"), icon: .image(globe)),
-        NavigationRow(title: "CellStyle", subtitle: .rightAligned(".value1"), icon: .image(time), action: showDetail()),
+        NavigationRow(title: "CellStyle", subtitle: .rightAligned(".value1"), icon: .image(time), actions: [showDetail()]),
         NavigationRow(title: "CellStyle", subtitle: .leftAligned(".value2"))
       ], footer: "UITableViewCellStyle.Value2 hides the image view."),
 
       RadioSection(title: "Radio Buttons", options: [
-        OptionRow(title: "Option 1", isSelected: true, action: didToggleSelection()),
-        OptionRow(title: "Option 2", isSelected: false, action: didToggleSelection()),
-        OptionRow(title: "Option 3", isSelected: false, action: didToggleSelection())
+        OptionRow(title: "Option 1", isSelected: true, actions: [didToggleSelection()]),
+        OptionRow(title: "Option 2", isSelected: false, actions: [didToggleSelection()]),
+        OptionRow(title: "Option 3", isSelected: false, actions: [didToggleSelection()])
       ], footer: "See RadioSection for more details."),
 
       debugging
@@ -80,43 +81,67 @@ internal final class DefaultViewController: QuickTableViewController {
 
   // MARK: - Private Methods
 
-  private func didToggleSelection() -> (Row) -> Void {
-    return { [weak self] in
+  private func didToggleSelection() -> RowActionType {
+    let action: (Row) -> Void = {
+      [weak self] in
       if let option = $0 as? OptionRowCompatible {
         let state = "\(option.title) is " + (option.isSelected ? "selected" : "deselected")
         self?.showDebuggingText(state)
       }
     }
+    let actionType: RowActionType = .defaultAction(action)
+    return actionType
   }
 
-  private func didToggleSwitch() -> (Row) -> Void {
-    return { [weak self] in
+  private func didToggleSwitch() -> RowActionType {
+    let action: (Row) -> Void = {
+      [weak self] in
       if let row = $0 as? SwitchRowCompatible {
         let state = "\(row.title) = \(row.switchValue)"
         self?.showDebuggingText(state)
       }
     }
+    let actionType: RowActionType = .defaultAction(action)
+    return actionType
   }
 
-  private func showAlert() -> (Row) -> Void {
-    return { [weak self] _ in
+  private func showAlert() -> RowActionType {
+    let action: (Row) -> Void = {
+      [weak self] _ in
       let alert = UIAlertController(title: "Action Triggered", message: nil, preferredStyle: .alert)
       alert.addAction(UIAlertAction(title: "OK", style: .cancel) { [weak self] _ in
         self?.dismiss(animated: true, completion: nil)
       })
       self?.present(alert, animated: true, completion: nil)
     }
+    let actionType: RowActionType = .defaultAction(action)
+    return actionType
   }
 
-  private func showDetail() -> (Row) -> Void {
-    return { [weak self] in
+  private func showDetail() -> RowActionType {
+    let action: (Row) -> Void = {
+      [weak self] in
       let detail = $0.title + ($0.subtitle?.text ?? "")
       let controller = UIViewController()
-      controller.view.backgroundColor = .white
+      controller.view.backgroundColor = .blue
       controller.title = detail
       self?.navigationController?.pushViewController(controller, animated: true)
       self?.showDebuggingText(detail + " is selected")
     }
+    let actionType: RowActionType = .defaultAction(action)
+    return actionType
+  }
+
+  private func show3DTouchPreview() -> RowActionType {
+    let action: (Row) -> UIViewController? = {
+      let detail = $0.title + ($0.subtitle?.text ?? "")
+      let controller = UIViewController()
+      controller.view.backgroundColor = .blue
+      controller.title = detail
+      return controller
+    }
+    let actionType: RowActionType = .popViewController(action)
+    return actionType
   }
 
   private func showDebuggingText(_ text: String) {
@@ -126,5 +151,4 @@ internal final class DefaultViewController: QuickTableViewController {
       self?.tableView.reloadData()
     }
   }
-
 }

--- a/Example-iOS/ViewControllers/RootViewController.swift
+++ b/Example-iOS/ViewControllers/RootViewController.swift
@@ -40,21 +40,21 @@ internal final class RootViewController: QuickTableViewController {
 
     tableContents = [
       Section(title: "Default", rows: [
-        NavigationRow(title: "Use default cell types", subtitle: .none, action: { [weak self] _ in
+        NavigationRow(title: "Use default cell types", subtitle: .none, actions: [.defaultAction({ [weak self] _ in
           self?.navigationController?.pushViewController(DefaultViewController(), animated: true)
-        })
+        })])
       ]),
 
       Section(title: "Customization", rows: [
-        NavigationRow(title: "Use custom cell types", subtitle: .none, action: { [weak self] _ in
+        NavigationRow(title: "Use custom cell types", subtitle: .none, actions: [.defaultAction({ [weak self] _ in
           self?.navigationController?.pushViewController(CustomizationViewController(), animated: true)
-        })
+        })])
       ]),
 
       Section(title: "UIAppearance", rows: [
-        NavigationRow(title: "UILabel customization", subtitle: .none, action: { [weak self] _ in
+        NavigationRow(title: "UILabel customization", subtitle: .none, actions: [.defaultAction({ [weak self] _ in
           self?.navigationController?.pushViewController(AppearanceViewController(), animated: true)
-        })
+        })])
       ])
     ]
   }

--- a/Source/Protocol/Row.swift
+++ b/Source/Protocol/Row.swift
@@ -24,7 +24,12 @@
 //  SOFTWARE.
 //
 
-import Foundation
+import UIKit
+
+public enum RowActionType {
+  case defaultAction(((Row) -> Void))
+  case popViewController(((Row) -> UIViewController?))
+}
 
 /// Any type that conforms to this protocol is capable of representing a row in a table view.
 public protocol Row: class {
@@ -36,6 +41,5 @@ public protocol Row: class {
   var subtitle: Subtitle? { get }
 
   /// A closure related to the action of the row.
-  var action: ((Row) -> Void)? { get }
-
+  var actions: [RowActionType]? { get }
 }

--- a/Source/Rows/NavigationRow.swift
+++ b/Source/Rows/NavigationRow.swift
@@ -38,13 +38,13 @@ open class NavigationRow<T: UITableViewCell>: NavigationRowCompatible, Equatable
     subtitle: Subtitle,
     icon: Icon? = nil,
     customization: ((UITableViewCell, Row & RowStyle) -> Void)? = nil,
-    action: ((Row) -> Void)? = nil
+    actions: [RowActionType]? = nil
   ) {
     self.title = title
     self.subtitle = subtitle
     self.icon = icon
     self.customize = customization
-    self.action = action
+    self.actions = actions
   }
 
   // MARK: - Row
@@ -56,7 +56,7 @@ open class NavigationRow<T: UITableViewCell>: NavigationRowCompatible, Equatable
   public let subtitle: Subtitle?
 
   /// A closure that will be invoked when the row is selected.
-  public let action: ((Row) -> Void)?
+  public let actions: [RowActionType]?
 
   // MARK: - RowStyle
 
@@ -78,12 +78,12 @@ open class NavigationRow<T: UITableViewCell>: NavigationRowCompatible, Equatable
 
   /// Returns `.disclosureIndicator` when action is not nil, otherwise returns `.none`.
   public var accessoryType: UITableViewCell.AccessoryType {
-    return (action == nil) ? .none : .disclosureIndicator
+    return (actions == nil) ? .none : .disclosureIndicator
   }
 
   /// The `NavigationRow` is selectable when action is not nil.
   public var isSelectable: Bool {
-    return action != nil
+    return actions != nil
   }
 
   /// The additional customization during cell configuration.

--- a/Source/Rows/OptionRow.swift
+++ b/Source/Rows/OptionRow.swift
@@ -38,13 +38,13 @@ open class OptionRow<T: UITableViewCell>: OptionRowCompatible, Equatable {
     isSelected: Bool,
     icon: Icon? = nil,
     customization: ((UITableViewCell, Row & RowStyle) -> Void)? = nil,
-    action: ((Row) -> Void)?
+    actions: [RowActionType]?
   ) {
     self.title = title
     self.isSelected = isSelected
     self.icon = icon
     self.customize = customization
-    self.action = action
+    self.actions = actions
   }
 
   // MARK: - OptionRowCompatible
@@ -56,7 +56,17 @@ open class OptionRow<T: UITableViewCell>: OptionRowCompatible, Equatable {
         return
       }
       DispatchQueue.main.async {
-        self.action?(self)
+        guard let actions = self.actions else {
+          return
+        }
+        for actionType in actions {
+          switch actionType {
+          case .defaultAction(let action):
+            action(self)
+          case .popViewController:
+            break
+          }
+        }
       }
     }
   }
@@ -70,7 +80,7 @@ open class OptionRow<T: UITableViewCell>: OptionRowCompatible, Equatable {
   public let subtitle: Subtitle? = nil
 
   /// A closure that will be invoked when the `isSelected` is changed.
-  public let action: ((Row) -> Void)?
+  public let actions: [RowActionType]?
 
   // MARK: - RowStyle
 

--- a/Source/Rows/SwitchRow.swift
+++ b/Source/Rows/SwitchRow.swift
@@ -38,13 +38,13 @@ open class SwitchRow<T: SwitchCell>: SwitchRowCompatible, Equatable {
     switchValue: Bool,
     icon: Icon? = nil,
     customization: ((UITableViewCell, Row & RowStyle) -> Void)? = nil,
-    action: ((Row) -> Void)?
+    actions: [RowActionType]?
   ) {
     self.title = title
     self.switchValue = switchValue
     self.icon = icon
     self.customize = customization
-    self.action = action
+    self.actions = actions
   }
 
   // MARK: - SwitchRowCompatible
@@ -56,7 +56,17 @@ open class SwitchRow<T: SwitchCell>: SwitchRowCompatible, Equatable {
         return
       }
       DispatchQueue.main.async {
-        self.action?(self)
+        guard let actions = self.actions else {
+          return
+        }
+        for actionType in actions {
+          switch actionType {
+          case .defaultAction(let action):
+            action(self)
+          case .popViewController:
+            break
+          }
+        }
       }
     }
   }
@@ -70,7 +80,7 @@ open class SwitchRow<T: SwitchCell>: SwitchRowCompatible, Equatable {
   public let subtitle: Subtitle? = nil
 
   /// A closure that will be invoked when the `switchValue` is changed.
-  public let action: ((Row) -> Void)?
+  public let actions: [RowActionType]?
 
   // MARK: - RowStyle
 

--- a/Source/Rows/TapActionRow.swift
+++ b/Source/Rows/TapActionRow.swift
@@ -36,11 +36,11 @@ open class TapActionRow<T: TapActionCell>: TapActionRowCompatible, Equatable {
   public init(
     title: String,
     customization: ((UITableViewCell, Row & RowStyle) -> Void)? = nil,
-    action: ((Row) -> Void)?
+    actions: [RowActionType]?
   ) {
     self.title = title
     self.customize = customization
-    self.action = action
+    self.actions = actions
   }
 
   // MARK: - Row
@@ -52,7 +52,7 @@ open class TapActionRow<T: TapActionCell>: TapActionRowCompatible, Equatable {
   public let subtitle: Subtitle? = nil
 
   /// A closure that will be invoked when the row is selected.
-  public let action: ((Row) -> Void)?
+  public let actions: [RowActionType]?
 
   // MARK: - RowStyle
 
@@ -73,7 +73,7 @@ open class TapActionRow<T: TapActionCell>: TapActionRowCompatible, Equatable {
 
   /// The `TapActionRow` is selectable when action is not nil.
   public var isSelectable: Bool {
-    return action != nil
+    return actions != nil
   }
 
   /// The additional customization during cell configuration.


### PR DESCRIPTION
**Purpose**

This is a feature related to this issue #24, that implement the possibility to have a 3DTouch preview.

**Most important files changed**

- QuickTableViewController.swift
- Row.swift

**Considerations**

This PR is considered as work in progress to verify the implementation, we can also improve the naming.
The Tests haven't been updated yet, I will do it once the PR is approved.

**How to test**

I have added a new Tap Action Row 1 in the default cells section that support the preview action.
