### PR TITLE
Fix SwitchRow subtitles

### DIFF
--- a/Example-iOS/ViewControllers/ExampleViewController.swift
+++ b/Example-iOS/ViewControllers/ExampleViewController.swift
@@ -45,7 +45,7 @@ internal final class ExampleViewController: QuickTableViewController {
 
     tableContents = [
       Section(title: "Switch", rows: [
-        SwitchRow(text: "Setting 1", switchValue: true, icon: .image(globe), action: didToggleSwitch()),
+        SwitchRow(text: "Setting 1", detailText: .subtitle("Example subtitle"), switchValue: true, icon: .image(globe), action: didToggleSwitch()),
         SwitchRow(text: "Setting 2", switchValue: false, icon: .image(time), action: didToggleSwitch())
       ]),
 

--- a/Example-iOSUITests/ExampleUITests.swift
+++ b/Example-iOSUITests/ExampleUITests.swift
@@ -42,11 +42,11 @@ internal final class ExampleUITests: XCTestCase {
     let tables = XCUIApplication().tables
     let existance = NSPredicate(format: "exists == true")
 
-    tables.switches["Setting 1"].tap()
+    tables.switches.firstMatch.tap()
     expectation(for: existance, evaluatedWith: tables.staticTexts["Setting 1 = false"], handler: nil)
     waitForExpectations(timeout: 5, handler: nil)
 
-    tables.switches["Setting 1"].tap()
+    tables.switches.firstMatch.tap()
     expectation(for: existance, evaluatedWith: tables.staticTexts["Setting 1 = true"], handler: nil)
     waitForExpectations(timeout: 5, handler: nil)
 

--- a/Source/Rows/SwitchRow.swift
+++ b/Source/Rows/SwitchRow.swift
@@ -83,7 +83,9 @@ open class SwitchRow<T: SwitchCell>: SwitchRowCompatible, Equatable {
   public let cellReuseIdentifier: String = T.reuseIdentifier
 
   /// Returns the table view cell style for the specified detail text.
-  public let cellStyle: UITableViewCell.CellStyle = .subtitle
+  public var cellStyle: UITableViewCell.CellStyle {
+    return detailText?.style ?? .subtitle
+  }
 
   /// The icon of the row.
   public let icon: Icon?

--- a/Source/Rows/SwitchRow.swift
+++ b/Source/Rows/SwitchRow.swift
@@ -83,7 +83,7 @@ open class SwitchRow<T: SwitchCell>: SwitchRowCompatible, Equatable {
   public let cellReuseIdentifier: String = T.reuseIdentifier
 
   /// The cell style is `.default`.
-  public let cellStyle: UITableViewCell.CellStyle = .default
+  public let cellStyle: UITableViewCell.CellStyle = .subtitle
 
   /// The icon of the row.
   public let icon: Icon?

--- a/Source/Rows/SwitchRow.swift
+++ b/Source/Rows/SwitchRow.swift
@@ -82,7 +82,7 @@ open class SwitchRow<T: SwitchCell>: SwitchRowCompatible, Equatable {
   /// The reuse identifier of the table view cell to display the row. The default value is **SwitchCell**.
   public let cellReuseIdentifier: String = T.reuseIdentifier
 
-  /// The cell style is `.default`.
+  /// Returns the table view cell style for the specified detail text.
   public let cellStyle: UITableViewCell.CellStyle = .subtitle
 
   /// The icon of the row.


### PR DESCRIPTION
This pull request enables SwitchRow subtitles, previously the `detailText` value would not be displayed.