### PR TITLE
Fix jitter caused by including headers/footers

### DIFF
--- a/Source/QuickTableViewController.swift
+++ b/Source/QuickTableViewController.swift
@@ -81,9 +81,15 @@ open class QuickTableViewController: UIViewController, UITableViewDataSource, UI
     tableView.frame = view.bounds
     tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     tableView.rowHeight = UITableView.automaticDimension
-    tableView.estimatedRowHeight = 44
     tableView.dataSource = self
     tableView.delegate = self
+
+    // Fixes bug where headers and footers were causing UITableView to act jumpy
+    // after a user has pushed a radio button and scrolls up. Originally came
+    // from https://developer.apple.com/forums/thread/86703.
+    tableView.estimatedRowHeight = 0
+    tableView.estimatedSectionHeaderHeight = 0
+    tableView.estimatedSectionFooterHeight = 0
   }
 
   open override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
It appears that something strange happens when a section has a header and footer. It is not obvious but if a user scrolls to the bottom of a QuickTableViewController, selects a radio button and then tries to scroll up, there is a bit of jitter. This only happens when there are headers/footers and the amount it shifts is completely dependent on the header/footer height.