### PR TITLE
[Feature] Override heightForRowAt

### DIFF
--- a/Source/QuickTableViewController.swift
+++ b/Source/QuickTableViewController.swift
@@ -95,6 +95,10 @@ open class QuickTableViewController: UIViewController, UITableViewDataSource, UI
 
   // MARK: - UITableViewDataSource
 
+  open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    return tableView.estimatedRowHeight
+  }
+  
   open func numberOfSections(in tableView: UITableView) -> Int {
     return tableContents.count
   }


### PR DESCRIPTION
Override the heightForRowAt function to enable users to customise height for rows in the table view. This is a very simple yet useful function.