### PR TITLE
Prevent animation of radio cells

### DIFF
--- a/Source/QuickTableViewController.swift
+++ b/Source/QuickTableViewController.swift
@@ -148,7 +148,7 @@ open class QuickTableViewController: UIViewController, UITableViewDataSource, UI
       if changes.isEmpty {
         tableView.deselectRow(at: indexPath, animated: false)
       } else {
-        tableView.reloadRows(at: changes, with: .automatic)
+        tableView.reloadRows(at: changes, with: .none)
       }
 
     case let (_, option as OptionRowCompatible):


### PR DESCRIPTION
This pull request removes the animation of radio table cells. On iOS, this stops a cell from flashing on tap, on tvOS this now matches the behavior of `SwitchRowCompatible` cells.